### PR TITLE
add disabling of URLs to Neuralyzer

### DIFF
--- a/config/webpack.contentScripts.js
+++ b/config/webpack.contentScripts.js
@@ -16,7 +16,10 @@ module.exports = function neuralyzerConfig(env) {
 
   return merge(env.WEBPACK_SERVE ? devConfig : prodConfig, {
     name: 'neuralyzerConfig',
-    entry: { neuralyzer: './src/contentScripts/neuralyzer.js' },
+    entry: {
+      neuralyzer: './src/contentScripts/neuralyzer.js',
+      'disable-links': './src/contentScripts/disable-links.js',
+    },
     output: {
       publicPath: '',
     },

--- a/manifest.json
+++ b/manifest.json
@@ -9,11 +9,13 @@
           "*://*/*"
         ],
         "js": [
-          "neuralyzer.js"
+          "neuralyzer.js",
+          "disable-links.js"
         ],
         "css": [
           "neuralyzer.css"
-        ]
+        ],
+        "all_frames": true
       }
     ],
     "action": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "neuralyzer",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "description": "A Chrome plugin that has the ability to bring the kiosk back to its homepage from any other websites",
     "repository": "git@github.com:xavierp1992/neuralyzer.git",
     "private": true,

--- a/src/contentScripts/disable-links.js
+++ b/src/contentScripts/disable-links.js
@@ -1,0 +1,139 @@
+function log(...args) {
+  console.log('[DisableLinks]', ...args);
+}
+
+function markAnchorDisabled(anchor) {
+  if (!anchor) return;
+
+  // Only process once
+  if (anchor.dataset.disableLinksProcessed === 'true') return;
+  anchor.dataset.disableLinksProcessed = 'true';
+
+  const originalHref = anchor.getAttribute('href');
+  if (!anchor.dataset.originalHref && originalHref) {
+    anchor.dataset.originalHref = originalHref;
+  }
+
+  log('Disabling anchor:', {
+    text: anchor.textContent?.trim(),
+    href: originalHref,
+    classes: anchor.className,
+  });
+
+  // Remove href + block interactions
+  anchor.removeAttribute('href');
+  anchor.style.pointerEvents = 'none';
+  anchor.style.cursor = 'default';
+  anchor.style.color = 'inherit';
+  anchor.setAttribute('aria-disabled', 'true');
+}
+
+function collectAllLinks(root = document) {
+  const links = [];
+  links.push(...root.querySelectorAll('a[href]'));
+  console.log('links', links);
+  const allElements = root.querySelectorAll('*');
+  allElements.forEach((el) => {
+    if (el.shadowRoot) {
+      log('Found shadowRoot in element:', el);
+      links.push(...collectAllLinks(el.shadowRoot));
+    }
+  });
+  return links;
+}
+function disableAllCurrentAnchors() {
+  const anchors = collectAllLinks(document);
+  log(`Found ${anchors.length} anchors to disable.`);
+  anchors.forEach(markAnchorDisabled);
+}
+
+function setupGlobalClickBlocker() {
+  document.addEventListener(
+    'click',
+    (event) => {
+      const anchor =
+        event.target && event.target.closest ? event.target.closest('a') : null;
+      if (!anchor) {
+        console.log('no anchor');
+        return;
+      }
+
+      // If it has an href OR we previously marked it, block it
+      const href = anchor.getAttribute('href') || anchor.dataset.originalHref;
+      if (!href) return;
+
+      log('Blocking click on:', {
+        text: anchor.textContent?.trim(),
+        href,
+        classes: anchor.className,
+      });
+
+      anchor.style.pointerEvents = 'none';
+      anchor.style.cursor = 'default';
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation?.();
+    },
+    true // capture phase: we see the click before the page does
+  );
+}
+
+function setupMutationObserver() {
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      m.addedNodes.forEach((node) => {
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+        const el = /** @type {HTMLElement} */ (node);
+
+        // If the added node is an <a>, process it
+        if (el.tagName === 'A') {
+          markAnchorDisabled(el);
+        }
+
+        // Also process any <a> inside it
+        const anchors = el.querySelectorAll?.('a[href]');
+        if (anchors && anchors.length) {
+          anchors.forEach(markAnchorDisabled);
+        }
+      });
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    attributes: true,
+    childList: true,
+    subtree: true,
+  });
+
+  log('MutationObserver for new anchors is set up.');
+}
+
+function shouldDisableForUrl(url, patterns) {
+  return patterns.some((pattern) => pattern && url.includes(pattern));
+}
+
+// Entry point
+chrome.storage.sync.get({ disableLinkUrls: [] }, (result) => {
+  const patterns = result.disableLinkUrls || [];
+  const currentUrl = window.location.href;
+
+  log('Current page URL:', currentUrl);
+  log('Disable-link patterns:', patterns);
+
+  if (!shouldDisableForUrl(currentUrl, patterns)) {
+    log('No matching pattern; not disabling links on this page.');
+    return;
+  }
+
+  log('Disabling links on this page.');
+
+  // 1) Block current anchors
+  disableAllCurrentAnchors();
+
+  // 2) try to block future anchors added by React/SPA
+  setupMutationObserver();
+
+  // 3) Hard block all anchor clicks at the document level
+  setupGlobalClickBlocker();
+});

--- a/src/contentScripts/disable-links.js
+++ b/src/contentScripts/disable-links.js
@@ -31,7 +31,6 @@ function markAnchorDisabled(anchor) {
 function collectAllLinks(root = document) {
   const links = [];
   links.push(...root.querySelectorAll('a[href]'));
-  console.log('links', links);
   const allElements = root.querySelectorAll('*');
   allElements.forEach((el) => {
     if (el.shadowRoot) {
@@ -118,7 +117,6 @@ chrome.storage.sync.get({ disableLinkUrls: [] }, (result) => {
   const patterns = result.disableLinkUrls || [];
   const currentUrl = window.location.href;
 
-  log('Current page URL:', currentUrl);
   log('Disable-link patterns:', patterns);
 
   if (!shouldDisableForUrl(currentUrl, patterns)) {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -30,6 +30,17 @@
         </form>
       </div>
     </section>
+    <section class="container">
+      <h2>Disable links on these pages</h2>
+      <div>
+        <p>Enter one URL or partial URL per line.</p>
+        <textarea id="disableUrls" rows="6" cols="60"></textarea>
+        <br />
+        <button id="save-disable-links">Save</button>
+        <span id="disable-links-status"></span>
+      </div>
+      <a href="https://www.google.com" target="_blank">Test</a>
+    </section>
   </main>
 </div>
 </body>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -39,7 +39,6 @@
         <button id="save-disable-links">Save</button>
         <span id="disable-links-status"></span>
       </div>
-      <a href="https://www.google.com" target="_blank">Test</a>
     </section>
   </main>
 </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -35,7 +35,9 @@ document.getElementById('save-disable-links').addEventListener('click', () => {
   const textarea = document.getElementById('disableUrls');
   const rawLines = textarea.value.split('\n');
 
-  const patterns = rawLines.map((l) => l.trim()).filter((l) => l.length > 0);
+  const patterns = rawLines
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
   chrome.storage.sync.set({ disableLinkUrls: patterns }, () => {
     const status = document.getElementById('disable-links-status');
     status.textContent = 'Saved!';

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -5,6 +5,10 @@ chrome.storage.sync.get(OPTION_KEYS, function (config) {
     (key) => (document.getElementById(key).value = config[key] || '')
   );
 });
+chrome.storage.sync.get({ disableLinkUrls: [] }, (result) => {
+  const textarea = document.getElementById('disableUrls');
+  textarea.value = result.disableLinkUrls.join('\n');
+});
 
 document.getElementById('configuration').onsubmit = function (event) {
   event.preventDefault();
@@ -25,3 +29,18 @@ document.getElementById('configuration').onsubmit = function (event) {
     }, 1500);
   });
 };
+// options/options.js
+
+document.getElementById('save-disable-links').addEventListener('click', () => {
+  const textarea = document.getElementById('disableUrls');
+  const rawLines = textarea.value.split('\n');
+
+  const patterns = rawLines.map((l) => l.trim()).filter((l) => l.length > 0);
+  chrome.storage.sync.set({ disableLinkUrls: patterns }, () => {
+    const status = document.getElementById('disable-links-status');
+    status.textContent = 'Saved!';
+    setTimeout(() => {
+      status.textContent = '';
+    }, 1500);
+  });
+});


### PR DESCRIPTION
Context:

Previously, uBlock Origin has a feature that allows users to add CSS elements that they do not want to be clickable.

uBlock Origin is deprecated in Chrome versions, thus a similar feature has been added to Neuralyzer to prevent links on listed sites to be unclickable.


Changes:
- Added a content script for disabling links
  - If URL matches the list in Neuralyzer, searches for all <a> tags in the HTML that contains a href, and prevent them from being clickable.