### PR TITLE
fix URLs not being disabled in shadowRoots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "neuralyzer",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "description": "A Chrome plugin that has the ability to bring the kiosk back to its homepage from any other websites",
     "repository": "git@github.com:xavierp1992/neuralyzer.git",
     "private": true,


### PR DESCRIPTION
Changes:

A fix for the previous [PR](https://github.com/xavierp1992/neuralyzer/pull/13)

Previously, elements in shadowRoots are not checked if the page is dynamically rendered.

Added a check when clicking elements. when element is a shadowRoot, checks if there are any <a> tags in it, and disables the links if <a> tags exist.

