### PR TITLE
fix reset button appearing on recaptcha

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,8 +14,7 @@
         ],
         "css": [
           "neuralyzer.css"
-        ],
-        "all_frames": true
+        ]
       }
     ],
     "action": {


### PR DESCRIPTION
Changes:
A fix for a bug introduced in v0.1.12.
In Neuralyzer, there is a "reset" button that when clicked multiple times, will send users back to the specified homepage.
In v0.1.12, `all_frames` were set to true in our manifest.json config while trying to fix an issue where <a> tags are not checked in shadowRoot. This caused an issue where the "reset" button is now displayed on all iframes, for instance ads and recaptchas.

Fix:

Since `all_frames` were not required to fix our issues with shadowRoots, we can safely disable it to fix this reset button appearing on all iframes.