### PR TITLE
add manual maintenance toggle to Neuralyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "neuralyzer",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "description": "A Chrome plugin that has the ability to bring the kiosk back to its homepage from any other websites",
     "repository": "git@github.com:xavierp1992/neuralyzer.git",
     "private": true,

--- a/src/contentScripts/status.js
+++ b/src/contentScripts/status.js
@@ -4,7 +4,7 @@ export function subscribeStatus({ statusUrl, url }) {
   const eventSrc = new EventSource(statusUrl);
   eventSrc.onmessage = function (event) {
     const manualMaintenanceMessage =
-      'We are upgrading our systems to serve you better. \n For urgent supply reconnections, please call 6671 7100. \n Bill payments may be made via internet banking, AXS, or at 7-Eleven stores and DBS/POSB/OCBC ATMs \n. Thank you for your understanding.';
+      'We are upgrading our systems to serve you better. \n. Thank you for your understanding.';
     chrome.storage.sync
       .get({ isManualMaintenance: false })
       .then(({ isManualMaintenance }) => {

--- a/src/contentScripts/status.js
+++ b/src/contentScripts/status.js
@@ -3,13 +3,11 @@ export function subscribeStatus({ statusUrl, url }) {
   const popId = 'neuralyzerMsg';
   const eventSrc = new EventSource(statusUrl);
   eventSrc.onmessage = function (event) {
-    console.log({ event });
     const manualMaintenanceMessage =
       'We are upgrading our systems to serve you better. \n For urgent supply reconnections, please call 6671 7100. \n Bill payments may be made via internet banking, AXS, or at 7-Eleven stores and DBS/POSB/OCBC ATMs \n. Thank you for your understanding.';
     chrome.storage.sync
       .get({ isManualMaintenance: false })
       .then(({ isManualMaintenance }) => {
-        console.log('isManualMaintenance', isManualMaintenance);
         const maintenance = JSON.parse(event.data);
         let popup = document.getElementById(popId);
         if (maintenance.isMaintenance || isManualMaintenance) {

--- a/src/contentScripts/status.js
+++ b/src/contentScripts/status.js
@@ -4,20 +4,27 @@ export function subscribeStatus({ statusUrl, url }) {
   const eventSrc = new EventSource(statusUrl);
   eventSrc.onmessage = function (event) {
     console.log({ event });
-    const maintenance = JSON.parse(event.data);
-    let popup = document.getElementById(popId);
-    if (maintenance.isMaintenance) {
-      if (!popup) {
-        popup = generatePopupNode();
-      }
-      popup.innerText = '';
-      generateContentNodes(maintenance.message).forEach(
-        popup.appendChild.bind(popup)
-      );
-    } else if (popup) {
-      popup.remove();
-      window.location.href = url;
-    }
+    const manualMaintenanceMessage =
+      'We are upgrading our systems to serve you better. \n For urgent supply reconnections, please call 6671 7100. \n Bill payments may be made via internet banking, AXS, or at 7-Eleven stores and DBS/POSB/OCBC ATMs \n. Thank you for your understanding.';
+    chrome.storage.sync
+      .get({ isManualMaintenance: false })
+      .then(({ isManualMaintenance }) => {
+        console.log('isManualMaintenance', isManualMaintenance);
+        const maintenance = JSON.parse(event.data);
+        let popup = document.getElementById(popId);
+        if (maintenance.isMaintenance || isManualMaintenance) {
+          if (!popup) {
+            popup = generatePopupNode();
+          }
+          popup.innerText = '';
+          generateContentNodes(
+            isManualMaintenance ? manualMaintenanceMessage : maintenance.message
+          ).forEach(popup.appendChild.bind(popup));
+        } else if (popup) {
+          popup.remove();
+          window.location.href = url;
+        }
+      });
   };
   eventSrc.onerror = function () {
     eventSrc.close();

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -27,3 +27,42 @@ footer {
     font-size: 0.8em;
     text-align: center;
 }
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;   /* normal size */
+  height: 20px;
+}
+
+.switch input {
+  display: none;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: #ccc;
+  border-radius: 20px;
+  transition: 0.25s;
+}
+
+.slider::before {
+  content: "";
+  position: absolute;
+  height: 16px;   /* knob size */
+  width: 16px;
+  left: 2px;
+  top: 2px;
+  background: white;
+  border-radius: 50%;
+  transition: 0.25s;
+}
+
+.switch input:checked + .slider {
+  background: #4caf50;
+}
+
+.switch input:checked + .slider::before {
+  transform: translateX(20px);
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -31,6 +31,17 @@
       </div>
     </section>
     <section class="container">
+      <h2>Toggle Maintenance For This Kiosk</h2>
+        <div class="input-group">
+          <label class="switch" for="toggleMaintenance">
+            <input type ="checkbox" id = "toggleMaintenance">
+            <span class ="slider"></span>
+          </label>
+          <span id="manualMaintenance"></span>
+        </div>
+
+    </section>
+    <section class="container">
       <h2>Disable links on these pages</h2>
       <div>
         <p>Enter one URL or partial URL per line.</p>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -9,7 +9,13 @@ chrome.storage.sync.get({ disableLinkUrls: [] }, (result) => {
   const textarea = document.getElementById('disableUrls');
   textarea.value = result.disableLinkUrls.join('\n');
 });
-
+chrome.storage.sync.get({ isManualMaintenance: false }, (result) => {
+  const statusText = document.getElementById('manualMaintenance');
+  const slider = document.getElementById('toggleMaintenance');
+  console.log('result', result);
+  statusText.textContent = result.isManualMaintenance ? 'Online' : 'Offline';
+  slider.checked = result.isManualMaintenance;
+});
 document.getElementById('configuration').onsubmit = function (event) {
   event.preventDefault();
   const values = Object.values(event.target).reduce(function (
@@ -30,7 +36,19 @@ document.getElementById('configuration').onsubmit = function (event) {
   });
 };
 // options/options.js
-
+document
+  .getElementById('toggleMaintenance')
+  .addEventListener('change', (event) => {
+    const isChecked = event.target.checked;
+    const statusText = document.getElementById('manualMaintenance');
+    statusText.textContent = event.target.checked ? 'Online' : 'Offline';
+    chrome.storage.sync.set({ isManualMaintenance: isChecked }).then(
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        chrome.tabs.reload(tabs[0].id);
+      })
+    );
+    console.log('maintenance toggled');
+  });
 document.getElementById('save-disable-links').addEventListener('click', () => {
   const textarea = document.getElementById('disableUrls');
   const rawLines = textarea.value.split('\n');

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -48,7 +48,6 @@ document
         chrome.tabs.reload(tabs[0].id);
       })
     );
-    console.log('maintenance toggled');
   });
 document.getElementById('save-disable-links').addEventListener('click', () => {
   const textarea = document.getElementById('disableUrls');

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -9,13 +9,14 @@ chrome.storage.sync.get({ disableLinkUrls: [] }, (result) => {
   const textarea = document.getElementById('disableUrls');
   textarea.value = result.disableLinkUrls.join('\n');
 });
-chrome.storage.sync.get({ isManualMaintenance: false }, (result) => {
-  const statusText = document.getElementById('manualMaintenance');
-  const slider = document.getElementById('toggleMaintenance');
-  console.log('result', result);
-  statusText.textContent = result.isManualMaintenance ? 'Online' : 'Offline';
-  slider.checked = result.isManualMaintenance;
-});
+chrome.storage.sync
+  .get({ isManualMaintenance: false })
+  .then(({ isManualMaintenance }) => {
+    const statusText = document.getElementById('manualMaintenance');
+    const slider = document.getElementById('toggleMaintenance');
+    statusText.textContent = isManualMaintenance ? 'Online' : 'Offline';
+    slider.checked = isManualMaintenance;
+  });
 document.getElementById('configuration').onsubmit = function (event) {
   event.preventDefault();
   const values = Object.values(event.target).reduce(function (


### PR DESCRIPTION
# Context

Currently, when maintenance is toggled, all kiosks that are subscribed to Neuralyzer with the same backend called, will have their maintenance page turned on together. However, if we only want certain kiosks to be toggled with maintenance mode, we cannot subscribe to the same backend.

This is a manual workaround, where users will be required to toggle it manually on the kiosk, for whatever unexpected circumstances that might require a specific kiosk to be on maintenance mode.

# Changes

- Added a slider to toggle maintenance on or off
- Made sure that the page is refreshed, when manually toggling maintenance mode
- bump version to 0.1.15