### PR TITLE
Save kiosk previous step URL

### DIFF
--- a/config/webpack.contentScripts.js
+++ b/config/webpack.contentScripts.js
@@ -19,6 +19,7 @@ module.exports = function neuralyzerConfig(env) {
     entry: {
       neuralyzer: './src/contentScripts/neuralyzer.js',
       'disable-links': './src/contentScripts/disable-links.js',
+      'background.bundle': './src/background/background.js',
     },
     output: {
       publicPath: '',

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,13 @@
 {
     "manifest_version": 3,
     "permissions": [
-      "storage"
+      "storage",
+      "webNavigation",
+      "tabs"
     ],
+    "background": {
+      "service_worker": "background.bundle.js"
+    },
     "content_scripts": [
       {
         "matches": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "neuralyzer",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "description": "A Chrome plugin that has the ability to bring the kiosk back to its homepage from any other websites",
     "repository": "git@github.com:xavierp1992/neuralyzer.git",
     "private": true,

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,0 +1,31 @@
+// src/background/background.js
+const KIOSK_DOMAIN_PATTERNS = [
+  // DEV
+  /^localhost:5500$/,
+  // QA (kiosk.qa.spdigital.sg and kiosk-sit[number].qa.spdigital.sg)
+  /^kiosk(-sit\d+)?\.qa\.spdigital\.sg$/,
+  // PROD
+  /^kiosk\.spdigital\.sg$/,
+];
+
+function isKioskDomain(url) {
+  try {
+    const urlObj = new URL(url);
+    return KIOSK_DOMAIN_PATTERNS.some((pattern) => pattern.test(urlObj.host));
+  } catch (e) {
+    console.error("Can't check domain. The domain is invalid ", e);
+  }
+
+  return false;
+}
+
+function saveUrlIfKiosk(details) {
+  if (isKioskDomain(details.url)) {
+    chrome.storage.sync.set({ previousStepUrl: details.url });
+  }
+}
+
+// React Router uses pushState
+chrome.webNavigation.onHistoryStateUpdated.addListener(saveUrlIfKiosk);
+// Also track full page reloads
+chrome.webNavigation.onCompleted.addListener(saveUrlIfKiosk);

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,27 +1,11 @@
 // src/background/background.js
-const KIOSK_DOMAIN_PATTERNS = [
-  // DEV
-  /^localhost:5500$/,
-  // QA (kiosk.qa.spdigital.sg and kiosk-sit[number].qa.spdigital.sg)
-  /^kiosk(-sit\d+)?\.qa\.spdigital\.sg$/,
-  // PROD
-  /^kiosk\.spdigital\.sg$/,
-];
-
-function isKioskDomain(url) {
-  try {
-    const urlObj = new URL(url);
-    return KIOSK_DOMAIN_PATTERNS.some((pattern) => pattern.test(urlObj.host));
-  } catch (e) {
-    console.error("Can't check domain. The domain is invalid ", e);
-  }
-
-  return false;
-}
+import { isKioskDomain, KIOSK_PREVIOUS_URL_KEY } from '../constants';
 
 function saveUrlIfKiosk(details) {
   if (isKioskDomain(details.url)) {
-    chrome.storage.sync.set({ previousStepUrl: details.url });
+    chrome.storage.sync.set({
+      [KIOSK_PREVIOUS_URL_KEY]: details.url,
+    });
   }
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,1 @@
-export const OPTION_KEYS = ['url', 'statusUrl', 'kioskName'];
+export const OPTION_KEYS = ['url', 'statusUrl', 'kioskName', 'previousStepUrl'];

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,35 @@
-export const OPTION_KEYS = ['url', 'statusUrl', 'kioskName', 'previousStepUrl'];
+export const OPTION_KEYS = ['url', 'statusUrl', 'kioskName'];
+export const KIOSK_PREVIOUS_URL_KEY = 'previousStepUrl';
+
+export const KIOSK_DOMAIN_PATTERNS = [
+  // DEV
+  /^localhost:5500$/,
+  // QA (kiosk.qa.spdigital.sg and kiosk-sit[number].qa.spdigital.sg)
+  /^kiosk(-sit\d+)?\.qa\.spdigital\.sg$/,
+  // PROD
+  /^kiosk\.spdigital\.sg$/,
+];
+
+export const SINGPASS_DOMAIN_PATTERNS = [
+  /myinfo\.gov\.sg$/,
+  /singpass\.gov\.sg$/,
+];
+
+function isMatchDomain(url, patterns) {
+  try {
+    const urlObj = new URL(url);
+    return patterns.some((pattern) => pattern.test(urlObj.host));
+  } catch (e) {
+    console.error("Can't check domain. The domain is invalid ", e);
+  }
+
+  return false;
+}
+
+export function isKioskDomain(url) {
+  return isMatchDomain(url, KIOSK_DOMAIN_PATTERNS);
+}
+
+export function isSingpassDomain(url) {
+  return isMatchDomain(url, SINGPASS_DOMAIN_PATTERNS);
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,3 +33,17 @@ export function isKioskDomain(url) {
 export function isSingpassDomain(url) {
   return isMatchDomain(url, SINGPASS_DOMAIN_PATTERNS);
 }
+
+export function existsDomWithText(text) {
+  const xpath = `//*[contains(normalize-space(.), '${text}')]`;
+
+  return (
+    document.evaluate(
+      xpath,
+      document,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+      null
+    ).singleNodeValue !== null
+  );
+}

--- a/src/contentScripts/button.js
+++ b/src/contentScripts/button.js
@@ -1,0 +1,11 @@
+export function createNavigateButton(navigateUrl) {
+  const btn = document.createElement('button');
+  btn.id = 'neuralyzerNavigateBtn';
+  btn.textContent = 'Back to kiosk';
+
+  btn.addEventListener('click', () => {
+    window.location.replace(navigateUrl);
+  });
+
+  return btn;
+}

--- a/src/contentScripts/button.js
+++ b/src/contentScripts/button.js
@@ -1,7 +1,7 @@
 export function createNavigateButton(navigateUrl) {
   const btn = document.createElement('button');
   btn.id = 'neuralyzerNavigateBtn';
-  btn.textContent = 'Back to kiosk';
+  btn.textContent = 'Back to Application';
 
   btn.addEventListener('click', () => {
     window.location.replace(navigateUrl);

--- a/src/contentScripts/neuralyzer.css
+++ b/src/contentScripts/neuralyzer.css
@@ -33,3 +33,37 @@
     margin: auto;
     width: 200px;
 }
+
+#neuralyzerNavigateBtn {
+    position: fixed !important;
+    top: 250px !important;
+    left: 87px !important;
+    height: 52px !important;
+    width: 284px !important;
+    border-radius: 4px !important;
+    border: 1px solid #008587 !important;
+    background-color: #ffffff !important;
+    color: #008587 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    text-decoration: none !important;
+    cursor: pointer !important;
+    font-size: 16px !important;
+    font-weight: 500 !important;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;
+    line-height: 1.2 !important;
+    text-align: center !important;
+    box-shadow: none !important;
+    z-index: 999999 !important;
+    pointer-events: auto !important;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease !important;
+}
+
+#neuralyzerNavigateBtn:hover {
+    background-color: #e6f6f7 !important;
+}
+
+#neuralyzerNavigateBtn:active {
+    background-color: #d1eded !important;
+}

--- a/src/contentScripts/neuralyzer.js
+++ b/src/contentScripts/neuralyzer.js
@@ -4,7 +4,7 @@ import { createDot } from './dot';
 import { subscribeStatus } from './status';
 
 chrome.storage.sync.get(OPTION_KEYS, function (options) {
-  document.body.appendChild(createDot(options.url));
+  document.body.appendChild(createDot(options.previousStepUrl ?? options.url));
   const domain = options.url.substring(
     options.url.indexOf('https://') + 8,
     options.url.lastIndexOf('/')

--- a/src/contentScripts/neuralyzer.js
+++ b/src/contentScripts/neuralyzer.js
@@ -1,6 +1,6 @@
 import './neuralyzer.css';
 import {
-  isKioskDomain,
+  existsDomWithText,
   isSingpassDomain,
   KIOSK_PREVIOUS_URL_KEY,
   OPTION_KEYS,
@@ -42,10 +42,47 @@ chrome.storage.sync.get(OPTION_KEYS, function (options) {
 
 chrome.storage.sync.get([KIOSK_PREVIOUS_URL_KEY], function (value) {
   const currentURl = window.location.origin;
-  const isKiosk = isKioskDomain(currentURl);
   const isSingpass = isSingpassDomain(currentURl);
-  // Just show button when user is in singpass page
-  if (!isKiosk && isSingpass) {
-    document.body.appendChild(createNavigateButton(value?.previousStepUrl));
+
+  if (!isSingpass) {
+    return;
   }
+
+  const navigateUrl = value?.previousStepUrl;
+
+  function tryAddButton() {
+    if (!document.body) {
+      return false;
+    }
+    const button = document.getElementById('neuralyzerNavigateBtn');
+    const isSingpassFirstPage = existsDomWithText('Log in with Singpass');
+
+    if (isSingpassFirstPage) {
+      if (!button) {
+        document.body.appendChild(createNavigateButton(navigateUrl));
+      }
+      return true;
+    } else {
+      if (button) {
+        button.remove();
+      }
+      return false;
+    }
+  }
+
+  const observer = new MutationObserver(() => {
+    tryAddButton();
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  window.addEventListener('click', () => tryAddButton());
+  window.addEventListener('touchstart', () => tryAddButton(), {
+    passive: true,
+  });
+
+  tryAddButton();
 });

--- a/src/contentScripts/neuralyzer.js
+++ b/src/contentScripts/neuralyzer.js
@@ -1,10 +1,16 @@
 import './neuralyzer.css';
-import { OPTION_KEYS } from '../constants';
+import {
+  isKioskDomain,
+  isSingpassDomain,
+  KIOSK_PREVIOUS_URL_KEY,
+  OPTION_KEYS,
+} from '../constants';
 import { createDot } from './dot';
 import { subscribeStatus } from './status';
+import { createNavigateButton } from './button';
 
 chrome.storage.sync.get(OPTION_KEYS, function (options) {
-  document.body.appendChild(createDot(options.previousStepUrl ?? options.url));
+  document.body.appendChild(createDot(options.url));
   const domain = options.url.substring(
     options.url.indexOf('https://') + 8,
     options.url.lastIndexOf('/')
@@ -31,5 +37,15 @@ chrome.storage.sync.get(OPTION_KEYS, function (options) {
         window.location.href = options.url;
       }
     }, 3600000);
+  }
+});
+
+chrome.storage.sync.get([KIOSK_PREVIOUS_URL_KEY], function (value) {
+  const currentURl = window.location.origin;
+  const isKiosk = isKioskDomain(currentURl);
+  const isSingpass = isSingpassDomain(currentURl);
+  // Just show button when user is in singpass page
+  if (!isKiosk && isSingpass) {
+    document.body.appendChild(createNavigateButton(value?.previousStepUrl));
   }
 });


### PR DESCRIPTION
# Context

Currently, When customer go to myInfo, they can't back to previous step to change data in form then they must refill form again. A bad experience 

# Changes

- Add background to listen navigate event from browser
- Check if it's Kiosk domain then store the URL into storage
- Create util dot with URL just set to allow user back to previous step
- bump version to 0.1.16

