### PR TITLE
Add Status Polling during Active Maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "neuralyzer",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "description": "A Chrome plugin that has the ability to bring the kiosk back to its homepage from any other websites",
     "repository": "git@github.com:xavierp1992/neuralyzer.git",
     "private": true,

--- a/src/contentScripts/status.js
+++ b/src/contentScripts/status.js
@@ -1,8 +1,68 @@
 import failIcon from '../assets/fail.svg';
 export function subscribeStatus({ statusUrl, url }) {
   const popId = 'neuralyzerMsg';
+  const ONE_HOUR = 60 * 1000 * 60; // 1 hour in milliseconds
+  const baseAPI = statusUrl.replace('/subscribe', '');
+  const STREAM_IDLE_TIMEOUT_MS = 30 * 1000; // 30 seconds for 3 missed pings
+
+  let pollingTimer = null;
+  let watchdogTimer = null;
+
   const eventSrc = new EventSource(statusUrl);
+
+  const armWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    watchdogTimer = setTimeout(() => {
+      console.log('Did not receive heartbeat for the last 30 seconds');
+      reconnect();
+    }, STREAM_IDLE_TIMEOUT_MS);
+  };
+  const reconnect = () => {
+    clearTimeout(watchdogTimer);
+    if (eventSrc) {
+      eventSrc.close();
+      subscribeStatus({ statusUrl, url });
+    }
+  };
+
+  const startPolling = async () => {
+    if (pollingTimer) {
+      return;
+    }
+    pollingTimer = setTimeout(async () => {
+      try {
+        const res = await fetch(baseAPI);
+        const maintenance = await res.json();
+
+        const { isManualMaintenance } = await chrome.storage.sync.get({
+          isManualMaintenance: false,
+        });
+
+        if (!maintenance.enable && !isManualMaintenance) {
+          stopPolling();
+
+          const popup = document.getElementById(popId);
+          if (popup) popup.remove();
+
+          window.location.href = url;
+        }
+      } catch (err) {
+        console.error('Polling error:', err);
+      }
+    }, ONE_HOUR);
+  };
+
+  const stopPolling = () => {
+    if (pollingTimer) {
+      clearTimeout(pollingTimer);
+      pollingTimer = null;
+    }
+  };
+  eventSrc.onopen = () => {
+    armWatchdog();
+  };
   eventSrc.onmessage = function (event) {
+    armWatchdog();
     const manualMaintenanceMessage =
       'We are upgrading our systems to serve you better. \n. Thank you for your understanding.';
     chrome.storage.sync
@@ -18,6 +78,7 @@ export function subscribeStatus({ statusUrl, url }) {
           generateContentNodes(
             isManualMaintenance ? manualMaintenanceMessage : maintenance.message
           ).forEach(popup.appendChild.bind(popup));
+          startPolling();
         } else if (popup) {
           popup.remove();
           window.location.href = url;

--- a/src/contentScripts/status.js
+++ b/src/contentScripts/status.js
@@ -9,6 +9,9 @@ export function subscribeStatus({ statusUrl, url }) {
   let watchdogTimer = null;
 
   const eventSrc = new EventSource(statusUrl);
+  eventSrc.addEventListener('ping', function () {
+    armWatchdog();
+  });
 
   const armWatchdog = () => {
     clearTimeout(watchdogTimer);
@@ -17,6 +20,7 @@ export function subscribeStatus({ statusUrl, url }) {
       reconnect();
     }, STREAM_IDLE_TIMEOUT_MS);
   };
+
   const reconnect = () => {
     clearTimeout(watchdogTimer);
     if (eventSrc) {
@@ -24,7 +28,6 @@ export function subscribeStatus({ statusUrl, url }) {
       subscribeStatus({ statusUrl, url });
     }
   };
-
   const startPolling = async () => {
     if (pollingTimer) {
       return;
@@ -58,9 +61,11 @@ export function subscribeStatus({ statusUrl, url }) {
       pollingTimer = null;
     }
   };
+
   eventSrc.onopen = () => {
     armWatchdog();
   };
+
   eventSrc.onmessage = function (event) {
     armWatchdog();
     const manualMaintenanceMessage =


### PR DESCRIPTION
# Changes
- Added polling for maintenance status during active maintenance
- Add fallback to close SSE connection and re-open a new one when SSE connection no longer receives heartbeats 
- bump version to 0.1.16